### PR TITLE
bump versions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -49,12 +49,6 @@ ROI Hunter will automatically do these things for you:
 * choose the most effective dynamic banner/text templates.
 
 Plugin reflects our best practices from over 10 years of advertising experience in Google Ads and Facebook.
- 
-=== Subscription options:: ===
-* Extension basic plan: $0.00
-* Extension premium plan: $9.99 
-
-\* Extension do not cover your Google Ads and Facebook Ad Spend.
 
 === Try our demo ===
 [Click for open ROI Hunter Easy Demo](https://easy.roihunter.com/demo?utm_source=github&utm_campaign=github_readme&utm_medium=website&utm_content=magento1#demo)
@@ -90,44 +84,15 @@ If you would have any difficulty with the usage of this extension, or have any i
 
 == Screenshots ==
  
-1. Add description to the first screenshot screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
-the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets 
-directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png` 
-(or jpg, jpeg, gif).
-2. This is the second screen shot
+1. Connect your Google Ads Account
+2. Preview your Google Ads
+3. Set your daily budget for Google Ads
+4. Connect your Facebook
+5. Preview your Facebook Ads
+6. Give it some time and watch the results
+7. In settings you can see your connected accounts
 
 == Changelog ==
 
 = 1.0.0 =
-* feature send FB&ADS events when using ajax
-* fix price value for FB events
-
-= 0.0.6 =
-* fix cleanup issues
-* staging gulp
-
-= 0.0.5 =
-* Move settings to get_option() instead of using WC_Settings Class and show it directly in the menu
-* Fix RH_EASY_VERSION format 
-* Remove WC API user on plugin deactivation
-
-= 0.0.4 =
-* google-tracking + fb-tracking API jako DELETE
-* zabezpečení všech endpointů kromě check pomocí parametru clientToken
-* do iframu se posílá WooCommerce REST API URL + Consumer Key + Consumer Secret
-
-= 0.0.3 =
-* option "id" nahrazena "customer_id"
-* opraven problém s načítáním iframu
-* přidán parametr stagingActive a activeProfile přejmenován na activeBeProfile
-* check REST endpoint jako POST
-* content_ids jako pole IDček
-* google_conversion_id a google_conversion_label opraveno, upraveny špatně předané parametry, opraveno google_conversion_order_id
-* neposílat údaje při refreshi thankyou stránky
-* fbq skript upraven na nekonfliktní mód
-
-= 0.0.2 =
-* integrace FB tracking pixel
-
-= 0.0.1 = 
-* integrace WooCommerce & API
+* Final release

--- a/readme.txt
+++ b/readme.txt
@@ -16,14 +16,14 @@ WC tested up to: 3.5.2
 
 [ROI Hunter Easy](https://easy.roihunter.com/) helps power your WooCommerce store with Google and Facebook Remarketing. We know it's a pain to get dynamic remarketing up and running. Developers need to produce an xml feed in a certain format, you need to upload it to the platforms, correct wrong product formats, ask developers to put all codes to right places, set up audiences, connect everything together, go through dozens of settings, etc. 
 
-=== Benefits ===
+= Benefits =
 Re-engage your unconverted visitors through multiple channels. Engaging through both Facebook and Google Display Network will give you access to over 95% of internet users. And practically guarantee that you will be able to engage visitors after they leave your store without a purchase. 
 
 Advanced audience segmentation and bidding customization will provide your campaign with the highest efficiency levels possible. 
 
 Do you want to boost the power of your ads even further? Our premium level subscription gives you access to professionally designed Facebook Ad Overlays. With their help, you'll be able to stand out in the barrage of ads everyday internet user encounters and get the attention you deserve. 
 
-=== Setup is quick and easy ===
+= Setup is quick and easy =
 ROI Hunter Easy will take care of all the annoying tech settings so you can have professional remarketing campaigns in 4 simple steps:
 
 * Install the plugin to your WooCommerce store for Free
@@ -35,8 +35,9 @@ You do not need any technical requirements. ROI Hunter Easy does all settings fo
 
 **A separate Google Adwords account and Facebook Business Manager are required. ROI Hunter Easy is free. You only pay for your running ads directly to Google and Facebook. You can set up your budget directly in ROI Hunter Easy.**
 
-=== Features: ===
+= Features: =
 ROI Hunter will automatically do these things for you:
+
 * create product catalogue for your website
 * upload your product catalogue to Google
 * upload your product catalogue to Facebook
@@ -50,36 +51,37 @@ ROI Hunter will automatically do these things for you:
 
 Plugin reflects our best practices from over 10 years of advertising experience in Google Ads and Facebook.
 
-=== Try our demo ===
+= Try our demo =
 [Click for open ROI Hunter Easy Demo](https://easy.roihunter.com/demo?utm_source=github&utm_campaign=github_readme&utm_medium=website&utm_content=magento1#demo)
 
-=== Requirements ===
+= Requirements =
 - WooCommerce 3.4 and newer
 - Enabled pretty permalinks (required for WooCommerce REST API)
 
 == Installation ==
 
-=== 1. Install the plugin === 
+= 1. Install the plugin = 
 
 The latest versions are always available in the WordPress Repository, and you can choose one of your favorite ways to install it: 
+
 * automatically using [built-in plugin installer](https://codex.wordpress.org/Managing_Plugins#Automatic_Plugin_Installation) (recommended)
 * manually by [uploading a zip archive](https://codex.wordpress.org/Managing_Plugins#Manual_Plugin_Installation_by_FTP)
 * manually by [FTP](https://codex.wordpress.org/Managing_Plugins#Manual_Plugin_Installation_by_Uploading_a_Zip_Archive)
 
-=== 2. Complete the setup ===
+= 2. Complete the setup =
 
 After the installation, continue by click to `ROI Hunter Easy` menu item and follow the instructions in our Sign Up wizard.
 
-== Frequently asked questions ==
+== Frequently Asked Questions ==
 
-=== How to reset the plugin? ===
+= How to reset the plugin? =
 
 If you need to return the plugin to its original settings (for example when you used wrong Google account during login) you can delete all the plugin data via uninstalling and reinstalling it. 
 
 1. Go to the `Plugins`, click on `Deactivate` below the ROI Hunter Easy plugin name. After the plugin is deactivated, you will be able to `Delete` it. 
 1. At this time, all the plugin data stored in your database are safely removed. Now you can click on `Add new` button and install it again.
 
-=== Support ===
+= Support =
 If you would have any difficulty with the usage of this extension, or have any issues you would like to raise with us please feel free to submit a support ticket by emailing easy@roihunter.com.
 
 == Screenshots ==

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: roihuntereasy, vyskoczilova
 Tags: woocommerce, roi, google analytics, gtm, facebook pixel
 Requires at least: 4.6
-Tested up to: 5.0.1
+Tested up to: 5.0.2
 Requires PHP: 5.6.0
 Stable tag: trunk
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -2,13 +2,13 @@
 Contributors: roihuntereasy, vyskoczilova
 Tags: woocommerce, roi, google analytics, gtm, facebook pixel
 Requires at least: 4.6
-Tested up to: 5.0.2
+Tested up to: 5.0.1
 Requires PHP: 5.6.0
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 3.4.0
-WC tested up to: 3.4.5
+WC tested up to: 3.5.2
 
 [ROI Hunter Easy](https://easy.roihunter.com/) helps power your WooCommerce store with Google and Facebook Remarketing. 
 

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,14 @@ If you need to return the plugin to its original settings (for example when you 
 === Support ===
 If you would have any difficulty with the usage of this extension, or have any issues you would like to raise with us please feel free to submit a support ticket by emailing easy@roihunter.com.
 
+== Screenshots ==
+ 
+1. Add description to the first screenshot screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
+the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets 
+directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png` 
+(or jpg, jpeg, gif).
+2. This is the second screen shot
+
 == Changelog ==
 
 = 1.0.0 =

--- a/roi-hunter-easy-for-woocommerce.php
+++ b/roi-hunter-easy-for-woocommerce.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: ROI Hunter Easy for WooCommerce
 Description: Turn visitors into customers.
-Version:     0.0.6
+Version:     1.0.0
 Author:      ROI Hunter Easy
 Author URI:  https://easy.roihunter.com
 */
@@ -15,7 +15,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'RH_EASY_DIR', plugin_dir_path( __FILE__ ) );
 define( 'RH_EASY_URL', plugin_dir_url( __FILE__ ) );
 define( 'RH_EASY_BASENAME', plugin_basename( __FILE__ ) );
-define( 'RH_EASY_VERSION', '0.0.6' );
+define( 'RH_EASY_VERSION', '1.0.0' );
 define( 'RH_EASY_MIN_WC_VERSION', '3.4.0');
 
 /**


### PR DESCRIPTION
Update WP, WC & plugin versions to correct numbers.

@Vergil333 I would suggest completely removing changelog in `readme.txt` file and keep just something like this.

```
= 1.0.0 (2018-12-20) =
* initial release
```

@oparizek please, rename your screenshots to screenshot-1.jpg etc. and add a screenshot description to the readme.txt 