### PR TITLE
Fix activation crashes

### DIFF
--- a/includes/activation.php
+++ b/includes/activation.php
@@ -12,9 +12,22 @@ $helper = new RH_Easy_Helper();
 // Generate clientToken
 if( ! $helper->get_option('clientToken') ) {
 	
-	// Create token and update default options
+	// Create token 
+	if ( version_compare( PHP_VERSION, '7.0.0' ) >= 0 ) {
+		$client_token = bin2hex( random_bytes(16) );
+	} else {
+		// https://stackoverflow.com/questions/4356289/php-random-string-generator#answer-4356295
+		$characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		$charactersLength = strlen($characters);
+		$client_token = '';
+		for ($i = 0; $i < 32; $i++) {
+			$client_token .= $characters[rand(0, $charactersLength - 1)];
+		}
+	}
+	
+	// Update default options
 	$updated_options = array(
-		'clientToken' => bin2hex(openssl_random_pseudo_bytes(16)),
+		'clientToken' => $client_token,
 	);
 	$helper->update_options( $updated_options );
 	

--- a/includes/rest-api-endpoints.php
+++ b/includes/rest-api-endpoints.php
@@ -1,4 +1,3 @@
-
 <?php
 
 // If this file is called directly, abort.

--- a/readme.txt
+++ b/readme.txt
@@ -91,5 +91,8 @@ If you would have any difficulty with the usage of this extension, or have any i
 
 == Changelog ==
 
+= 1.0.1 = ( unreleased )
+* Fix: Generating client_token - use `random_bytes` instead of `openssl_random_pseudo_bytes` on PHP 7+, add fallback for older PHP versions.
+
 = 1.0.0 =
 * Final release

--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ If you would have any difficulty with the usage of this extension, or have any i
 
 == Changelog ==
 
-= 1.0.1 = ( unreleased )
+= 1.0.1 (2019-02-02) =
 * Fix: When generating the client_token - use `random_bytes` instead of `openssl_random_pseudo_bytes` on PHP 7+, add fallback for older PHP versions.
 * Fix: Check PHP version and prevent the plugin activation if PHP version is not at least 5.6.
 

--- a/readme.txt
+++ b/readme.txt
@@ -92,7 +92,8 @@ If you would have any difficulty with the usage of this extension, or have any i
 == Changelog ==
 
 = 1.0.1 = ( unreleased )
-* Fix: Generating client_token - use `random_bytes` instead of `openssl_random_pseudo_bytes` on PHP 7+, add fallback for older PHP versions.
+* Fix: When generating the client_token - use `random_bytes` instead of `openssl_random_pseudo_bytes` on PHP 7+, add fallback for older PHP versions.
+* Fix: Check PHP version and prevent the plugin activation if PHP version is not at least 5.6.
 
 = 1.0.0 =
 * Final release

--- a/readme.txt
+++ b/readme.txt
@@ -94,6 +94,7 @@ If you would have any difficulty with the usage of this extension, or have any i
 = 1.0.1 (2019-02-02) =
 * Fix: When generating the client_token - use `random_bytes` instead of `openssl_random_pseudo_bytes` on PHP 7+, add fallback for older PHP versions.
 * Fix: Check PHP version and prevent the plugin activation if PHP version is not at least 5.3.
+* Fix: Delete empty first line in `includes/rest-api-endpoints.php`
 
 = 1.0.0 =
 * Final release

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: roihuntereasy, vyskoczilova
 Tags: woocommerce, roi, google analytics, gtm, facebook pixel
 Requires at least: 4.6
 Tested up to: 5.0.2
-Requires PHP: 5.6.0
+Requires PHP: 5.3.0
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -93,7 +93,7 @@ If you would have any difficulty with the usage of this extension, or have any i
 
 = 1.0.1 (2019-02-02) =
 * Fix: When generating the client_token - use `random_bytes` instead of `openssl_random_pseudo_bytes` on PHP 7+, add fallback for older PHP versions.
-* Fix: Check PHP version and prevent the plugin activation if PHP version is not at least 5.6.
+* Fix: Check PHP version and prevent the plugin activation if PHP version is not at least 5.3.
 
 = 1.0.0 =
 * Final release

--- a/roi-hunter-easy-for-woocommerce.php
+++ b/roi-hunter-easy-for-woocommerce.php
@@ -113,7 +113,7 @@ function roi_hunter_easy_admin_notice() {
 
 	if ( version_compare( PHP_VERSION, '5.3.0' ) < 0 ) { 
 		
-		$error .= '<p>' . sprintf( __( '%1$s requires at least PHP 5.6. Contact your hosting provider for more support.</b>', 'roi-hunter-easy' ), $roi_hunter_easy_plugin ) . '</p>';
+		$error .= '<p>' . sprintf( __( '%1$s requires at least PHP 5.3. Contact your hosting provider for more support.</b>', 'roi-hunter-easy' ), $roi_hunter_easy_plugin ) . '</p>';
 
 	}
 

--- a/roi-hunter-easy-for-woocommerce.php
+++ b/roi-hunter-easy-for-woocommerce.php
@@ -33,7 +33,7 @@ add_action( 'plugins_loaded', 'roi_hunter_easy_plugin_init' );
 function roi_hunter_easy_plugin_init() {
 	
 	// If WooCommerce is NOT active, if not correct version or not pretty permalinks or old PHP version
-	if ( ! class_exists( 'woocommerce' ) || ! get_option('permalink_structure') || ( class_exists( 'woocommerce' ) && version_compare( wc()->version, RH_EASY_MIN_WC_VERSION, '<' ) ) || version_compare( PHP_VERSION, '5.6.0' ) < 0 ) {
+	if ( ! class_exists( 'woocommerce' ) || ! get_option('permalink_structure') || ( class_exists( 'woocommerce' ) && version_compare( wc()->version, RH_EASY_MIN_WC_VERSION, '<' ) ) || version_compare( PHP_VERSION, '5.3.0' ) < 0 ) {
 		
 		add_action( 'admin_init', 'roi_hunter_easy_deactivate' );
 		add_action( 'admin_notices', 'roi_hunter_easy_admin_notice' );
@@ -111,7 +111,7 @@ function roi_hunter_easy_admin_notice() {
 
 	}
 
-	if ( version_compare( PHP_VERSION, '5.6.0' ) < 0 ) { 
+	if ( version_compare( PHP_VERSION, '5.3.0' ) < 0 ) { 
 		
 		$error .= '<p>' . sprintf( __( '%1$s requires at least PHP 5.6. Contact your hosting provider for more support.</b>', 'roi-hunter-easy' ), $roi_hunter_easy_plugin ) . '</p>';
 

--- a/roi-hunter-easy-for-woocommerce.php
+++ b/roi-hunter-easy-for-woocommerce.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: ROI Hunter Easy for WooCommerce
 Description: Turn visitors into customers.
-Version:     1.0.0
+Version:     1.0.1
 Author:      ROI Hunter Easy
 Author URI:  https://easy.roihunter.com
 */
@@ -15,7 +15,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'RH_EASY_DIR', plugin_dir_path( __FILE__ ) );
 define( 'RH_EASY_URL', plugin_dir_url( __FILE__ ) );
 define( 'RH_EASY_BASENAME', plugin_basename( __FILE__ ) );
-define( 'RH_EASY_VERSION', '1.0.0' );
+define( 'RH_EASY_VERSION', '1.0.1' );
 define( 'RH_EASY_MIN_WC_VERSION', '3.4.0');
 
 /**

--- a/roi-hunter-easy-for-woocommerce.php
+++ b/roi-hunter-easy-for-woocommerce.php
@@ -32,8 +32,8 @@ function roi_hunter_easy_localize_plugin() {
 add_action( 'plugins_loaded', 'roi_hunter_easy_plugin_init' );
 function roi_hunter_easy_plugin_init() {
 	
-	// If WooCommerce is NOT active, if not correct version or not pretty permalinks
-	if ( ! class_exists( 'woocommerce' ) || ! get_option('permalink_structure') || ( class_exists( 'woocommerce' ) && version_compare( wc()->version, RH_EASY_MIN_WC_VERSION, '<' ) )) {
+	// If WooCommerce is NOT active, if not correct version or not pretty permalinks or old PHP version
+	if ( ! class_exists( 'woocommerce' ) || ! get_option('permalink_structure') || ( class_exists( 'woocommerce' ) && version_compare( wc()->version, RH_EASY_MIN_WC_VERSION, '<' ) ) || version_compare( PHP_VERSION, '5.6.0' ) < 0 ) {
 		
 		add_action( 'admin_init', 'roi_hunter_easy_deactivate' );
 		add_action( 'admin_notices', 'roi_hunter_easy_admin_notice' );
@@ -108,6 +108,12 @@ function roi_hunter_easy_admin_notice() {
 	if ( ! get_option('permalink_structure') ) { 
 
 		$error .= '<p>' . sprintf( __( '%1$s requires pretty permalinks enabled. Please enable pretty permalinks in your settings before activation of %1$s. <b>WARNING: In order to not to loose SEO of your page redirect all old URL to the new ones using your .htaccess and Redirect 301 rules.</b>', 'roi-hunter-easy' ), $roi_hunter_easy_plugin ) . '</p>';
+
+	}
+
+	if ( version_compare( PHP_VERSION, '5.6.0' ) < 0 ) { 
+		
+		$error .= '<p>' . sprintf( __( '%1$s requires at least PHP 5.6. Contact your hosting provider for more support.</b>', 'roi-hunter-easy' ), $roi_hunter_easy_plugin ) . '</p>';
 
 	}
 


### PR DESCRIPTION
* Fix: When generating the client_token - use `random_bytes` instead of `openssl_random_pseudo_bytes` on PHP 7+, add fallback for older PHP versions.
* Fix: Check PHP version and prevent the plugin activation if PHP version is not at least 5.3.

@oparizek Could you check, merge and I'll push it to the repo asap?